### PR TITLE
[FEAT] add comment paging feature

### DIFF
--- a/src/main/java/com/newspeed19/comment/controller/CommentController.java
+++ b/src/main/java/com/newspeed19/comment/controller/CommentController.java
@@ -2,6 +2,7 @@ package com.newspeed19.comment.controller;
 
 import java.util.List;
 
+import org.springframework.data.domain.Page;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -9,10 +10,12 @@ import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.bind.annotation.SessionAttribute;
 
 import com.newspeed19.comment.dto.request.CommentRequestDto;
+import com.newspeed19.comment.dto.response.CommentPageResponseDto;
 import com.newspeed19.comment.dto.response.CommentResponseDto;
 import com.newspeed19.comment.service.CommentService;
 
@@ -53,6 +56,16 @@ public class CommentController {
 		@PathVariable Long id) {
 		commentService.delete(id, userId);
 		return ResponseEntity.ok("삭제 완료");
+	}
+
+	@GetMapping("api/feed/{id}/comments/page")
+	public ResponseEntity<Page<CommentPageResponseDto>> findAllPage(
+		@PathVariable Long id,
+		@RequestParam(defaultValue = "1") int page,
+		@RequestParam(defaultValue = "10") int size
+	) {
+		Page<CommentPageResponseDto> result = commentService.findAllPage(id, page, size);
+		return ResponseEntity.ok(result);
 	}
 
 }

--- a/src/main/java/com/newspeed19/comment/dto/response/CommentPageResponseDto.java
+++ b/src/main/java/com/newspeed19/comment/dto/response/CommentPageResponseDto.java
@@ -1,0 +1,27 @@
+package com.newspeed19.comment.dto.response;
+
+import java.time.LocalDateTime;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class CommentPageResponseDto {
+	private final Long id;
+	private final Long userId;
+	private final Long feedId;
+	private final String content;
+	private final LocalDateTime createdAt;
+	private final LocalDateTime updatedAt;
+
+	@Builder
+	public CommentPageResponseDto(Long id, Long userId, Long feedId, String content, LocalDateTime createdAt,
+		LocalDateTime updatedAt) {
+		this.id = id;
+		this.userId = userId;
+		this.feedId = feedId;
+		this.content = content;
+		this.createdAt = createdAt;
+		this.updatedAt = updatedAt;
+	}
+}

--- a/src/main/java/com/newspeed19/comment/repository/CommentRepository.java
+++ b/src/main/java/com/newspeed19/comment/repository/CommentRepository.java
@@ -2,6 +2,8 @@ package com.newspeed19.comment.repository;
 
 import java.util.List;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.server.ResponseStatusException;
@@ -22,5 +24,17 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
 			throw new ResponseStatusException(HttpStatus.NOT_FOUND, "댓글이 없습니다.");
 		}
 		return comments;
+	}
+
+	Page<Comment> findAllByFeedId(Long feedId, Pageable pageable);
+
+	default Page<Comment> findAllByFeedIdOrElseThrow(Feed feed, Pageable pageable) {
+		Page<Comment> pageComment = findAllByFeedId(feed.getId(), pageable);
+
+		if (pageComment.isEmpty()) {
+			throw new ResponseStatusException(HttpStatus.NOT_FOUND, "댓글이 없습니다.");
+		}
+
+		return pageComment;
 	}
 }

--- a/src/main/java/com/newspeed19/comment/service/CommentService.java
+++ b/src/main/java/com/newspeed19/comment/service/CommentService.java
@@ -78,7 +78,6 @@ public class CommentService {
 	public Page<CommentPageResponseDto> findAllPage(Long feedId, int page, int size) {
 		int adjustedPage = (page > 0) ? page - 1 : 0;
 		PageRequest pageable = PageRequest.of(adjustedPage, size, Sort.by("updatedAt").descending());
-		// public static PageRequest of(int pageNumber, int pageSize, Sort sort)
 
 		Feed findFeed = feedRepository.findByIdOrElseThrow(feedId);
 		Page<Comment> commentPage = commentRepository.findAllByFeedIdOrElseThrow(findFeed, pageable);

--- a/src/main/java/com/newspeed19/comment/service/CommentService.java
+++ b/src/main/java/com/newspeed19/comment/service/CommentService.java
@@ -3,12 +3,16 @@ package com.newspeed19.comment.service;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.server.ResponseStatusException;
 
 import com.newspeed19.comment.dto.request.CommentRequestDto;
+import com.newspeed19.comment.dto.response.CommentPageResponseDto;
 import com.newspeed19.comment.dto.response.CommentResponseDto;
 import com.newspeed19.comment.entity.Comment;
 import com.newspeed19.comment.repository.CommentRepository;
@@ -70,4 +74,21 @@ public class CommentService {
 		commentRepository.delete(comment);
 	}
 
+	@Transactional(readOnly = true)
+	public Page<CommentPageResponseDto> findAllPage(Long feedId, int page, int size) {
+		int adjustedPage = (page > 0) ? page - 1 : 0;
+		PageRequest pageable = PageRequest.of(adjustedPage, size, Sort.by("updatedAt").descending());
+		// public static PageRequest of(int pageNumber, int pageSize, Sort sort)
+
+		Feed findFeed = feedRepository.findByIdOrElseThrow(feedId);
+		Page<Comment> commentPage = commentRepository.findAllByFeedIdOrElseThrow(findFeed, pageable);
+
+		return commentPage.map(comment -> CommentPageResponseDto.builder()
+			.id(comment.getId())
+			.userId(comment.getUser().getId())
+			.feedId(comment.getFeed().getId())
+			.content(comment.getContent())
+			.createdAt(comment.getCreatedAt())
+			.updatedAt(comment.getUpdatedAt()).build());
+	}
 }


### PR DESCRIPTION
## 🔎 작업 내용
- 코멘트 페이징 기능 추가했습니다.
- api 추가 : /api/feed/{id}/comments/page 

## ➕ 트러블 슈팅
- 처음해봤는데, 그냥 페이징 어려움 한 5번은 만들어봐야 감 잡힐 듯 합니다.

## 🔧 해결해야할 문제
- 인증, 피드, 유저 연동 필요.