### PR TITLE
[FEAT]: Feed(게시글) 예외 처리 및 공통 API 응답 수정

### DIFF
--- a/src/main/java/com/newspeed19/feed/controller/FeedController.java
+++ b/src/main/java/com/newspeed19/feed/controller/FeedController.java
@@ -1,8 +1,5 @@
 package com.newspeed19.feed.controller;
 
-import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Sort;
-import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
@@ -20,7 +17,7 @@ import com.newspeed19.feed.dto.request.FeedRequestDto;
 import com.newspeed19.feed.dto.request.FeedRequestGroups;
 import com.newspeed19.feed.dto.response.ApiResponseDto;
 import com.newspeed19.feed.dto.response.FeedDetailResponseDto;
-import com.newspeed19.feed.dto.response.PagedFeedResponseDto;
+import com.newspeed19.feed.dto.response.FeedPageResponseDto;
 import com.newspeed19.feed.service.FeedService;
 
 import lombok.RequiredArgsConstructor;
@@ -44,10 +41,10 @@ public class FeedController {
 	) {
 		FeedPageResponseDto responseDto = feedService.findAllFeed(page, size);
 
-		ApiResponseDto<PagedFeedResponseDto> apiResponseDto = ApiResponseDto.<PagedFeedResponseDto>builder()
-			.success(true)
+		ApiResponseDto<FeedPageResponseDto> apiResponseDto = ApiResponseDto.<FeedPageResponseDto>builder()
+			.code(HttpStatus.OK.value())
 			.message("전체 피드를 조회합니다.")
-			.httpStatus(HttpStatus.OK)
+			.status(HttpStatus.OK.getReasonPhrase())
 			.data(responseDto)
 			.build();
 		return new ResponseEntity<>(apiResponseDto, HttpStatus.OK);
@@ -65,9 +62,9 @@ public class FeedController {
 		FeedDetailResponseDto responseDto = feedService.findFeedById(id);
 
 		ApiResponseDto<FeedDetailResponseDto> apiResponseDto = ApiResponseDto.<FeedDetailResponseDto>builder()
-			.success(true)
+			.code(HttpStatus.OK.value())
 			.message("상세 피드를 조회합니다.")
-			.httpStatus(HttpStatus.OK)
+			.status(HttpStatus.OK.getReasonPhrase())
 			.data(responseDto)
 			.build();
 		return new ResponseEntity<>(apiResponseDto, HttpStatus.OK);
@@ -85,9 +82,9 @@ public class FeedController {
 		FeedDetailResponseDto responseDto = feedService.createFeed(dto);
 
 		ApiResponseDto<FeedDetailResponseDto> apiResponseDto = ApiResponseDto.<FeedDetailResponseDto>builder()
-			.success(true)
+			.code(HttpStatus.CREATED.value())
 			.message("피드를 생성하였습니다.")
-			.httpStatus(HttpStatus.CREATED)
+			.status(HttpStatus.CREATED.getReasonPhrase())
 			.data(responseDto)
 			.build();
 		return new ResponseEntity<>(apiResponseDto, HttpStatus.CREATED);
@@ -107,9 +104,9 @@ public class FeedController {
 		FeedDetailResponseDto responseDto = feedService.updateFeed(dto, id);
 
 		ApiResponseDto<FeedDetailResponseDto> apiResponseDto = ApiResponseDto.<FeedDetailResponseDto>builder()
-			.success(true)
+			.code(HttpStatus.OK.value())
 			.message("피드를 성공적으로 수정하였습니다.")
-			.httpStatus(HttpStatus.OK)
+			.status(HttpStatus.OK.getReasonPhrase())
 			.data(responseDto)
 			.build();
 		return new ResponseEntity<>(apiResponseDto, HttpStatus.OK);
@@ -122,16 +119,16 @@ public class FeedController {
 	 * @return 업데이트된 페이징 피드 정보가 포함된 응답객체를 반환
 	 */
 	@DeleteMapping("/{id}")
-	public ResponseEntity<ApiResponseDto<PagedFeedResponseDto>> delete(
+	public ResponseEntity<ApiResponseDto<FeedPageResponseDto>> delete(
 		@PathVariable Long id,
 		@Validated(FeedRequestGroups.Delete.class) @RequestBody FeedRequestDto dto
 	) {
-		PagedFeedResponseDto responseDto = feedService.deleteFeed(id, dto.getPassword());
+		FeedPageResponseDto responseDto = feedService.deleteFeed(id, dto.getPassword());
 
-		ApiResponseDto<PagedFeedResponseDto> apiResponseDto = ApiResponseDto.<PagedFeedResponseDto>builder()
-			.success(true)
+		ApiResponseDto<FeedPageResponseDto> apiResponseDto = ApiResponseDto.<FeedPageResponseDto>builder()
+			.code(HttpStatus.OK.value())
 			.message("성공적으로 삭제하였습니다. 전체 피드를 반환합니다.")
-			.httpStatus(HttpStatus.OK)
+			.status(HttpStatus.OK.getReasonPhrase())
 			.data(responseDto)
 			.build();
 		return new ResponseEntity<>(apiResponseDto, HttpStatus.OK);

--- a/src/main/java/com/newspeed19/feed/dto/response/ApiResponseDto.java
+++ b/src/main/java/com/newspeed19/feed/dto/response/ApiResponseDto.java
@@ -1,7 +1,6 @@
 package com.newspeed19.feed.dto.response;
 
-import org.springframework.http.HttpStatus;
-
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 
 import lombok.Builder;
@@ -14,10 +13,12 @@ import lombok.Getter;
  */
 @Getter
 @Builder
-@JsonPropertyOrder({"success", "message", "httpStatus", "data"})
+@JsonPropertyOrder({"code", "status", "message", "data"})
 public class ApiResponseDto<T> {
-	private final boolean success;
-	private final String message;
-	private final HttpStatus httpStatus;
+	private final int code; // (ex. 200, 201, 401..)
+	private final String status; // (ex. OK, CREATED, NOT_FOUND...)
+	private final String message; // ex. 생성이 완료되었습니다.
+
+	@JsonInclude(JsonInclude.Include.NON_NULL) // null 값이 아닌 경우에만 출력
 	private final T data;
 }

--- a/src/main/java/com/newspeed19/feed/exception/CustomException.java
+++ b/src/main/java/com/newspeed19/feed/exception/CustomException.java
@@ -1,0 +1,19 @@
+package com.newspeed19.feed.exception;
+
+import org.springframework.http.HttpStatus;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class CustomException extends RuntimeException {
+	private final int code;
+	private final HttpStatus httpStatus;
+
+	@Builder
+	public CustomException(ExceptionCode exceptionCode) {
+		super(exceptionCode.getMessage());
+		this.httpStatus = exceptionCode.getHttpStatus();
+		this.code = exceptionCode.getCode();
+	}
+}

--- a/src/main/java/com/newspeed19/feed/exception/ExceptionCode.java
+++ b/src/main/java/com/newspeed19/feed/exception/ExceptionCode.java
@@ -1,0 +1,19 @@
+package com.newspeed19.feed.exception;
+
+import org.springframework.http.HttpStatus;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Getter
+public enum ExceptionCode {
+	/**
+	 * 3000: Feed 에러
+	 */
+	FEED_NOT_FOUND(3001, HttpStatus.NOT_FOUND, "존재하지 않는 피드입니다.");
+
+	private final int code;
+	private final HttpStatus httpStatus;
+	private final String message;
+}

--- a/src/main/java/com/newspeed19/feed/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/newspeed19/feed/handler/GlobalExceptionHandler.java
@@ -1,0 +1,28 @@
+package com.newspeed19.feed.handler;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import com.newspeed19.feed.dto.response.ApiResponseDto;
+import com.newspeed19.feed.exception.CustomException;
+
+@RestControllerAdvice // FIXME: 추후 공통 예외 핸들러로 빼야될 핸들러
+public class GlobalExceptionHandler {
+
+	/**
+	 * 공통 예외 핸들러
+	 * @param exception 예외 객체
+	 * @return 예외정보와 함께 API 응답객체를 반환
+	 */
+	@ExceptionHandler(CustomException.class)
+	public ResponseEntity<ApiResponseDto<Void>> handleException(CustomException exception) {
+		// API 응답 객체 생성
+		ApiResponseDto<Void> apiResponseDto = ApiResponseDto.<Void>builder()
+			.code(exception.getCode())
+			.message(exception.getMessage())
+			.status(exception.getHttpStatus().getReasonPhrase())
+			.build();
+		return ResponseEntity.status(exception.getHttpStatus()).body(apiResponseDto);
+	}
+}

--- a/src/main/java/com/newspeed19/feed/service/FeedService.java
+++ b/src/main/java/com/newspeed19/feed/service/FeedService.java
@@ -4,7 +4,6 @@ import java.util.List;
 
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
@@ -13,10 +12,11 @@ import org.springframework.web.server.ResponseStatusException;
 
 import com.newspeed19.feed.dto.request.FeedRequestDto;
 import com.newspeed19.feed.dto.response.FeedDetailResponseDto;
+import com.newspeed19.feed.dto.response.FeedPageResponseDto;
 import com.newspeed19.feed.dto.response.FeedResponseDto;
-import com.newspeed19.feed.dto.response.PageResponseDto;
-import com.newspeed19.feed.dto.response.PagedFeedResponseDto;
 import com.newspeed19.feed.entity.Feed;
+import com.newspeed19.feed.exception.CustomException;
+import com.newspeed19.feed.exception.ExceptionCode;
 import com.newspeed19.feed.repository.FeedRepository;
 
 import lombok.RequiredArgsConstructor;
@@ -68,7 +68,10 @@ public class FeedService {
 	@Transactional(readOnly = true)
 	public FeedDetailResponseDto findFeedById(Long id) {
 		Feed feed = feedRepository.findById(id)
-			.orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "존재하지 않는 게시글입니다."));
+			.orElseThrow(() -> CustomException
+				.builder()
+				.exceptionCode(ExceptionCode.FEED_NOT_FOUND)
+				.build());
 
 		return FeedDetailResponseDto.builder()
 			.id(feed.getId())
@@ -143,26 +146,13 @@ public class FeedService {
 	 * @return 업데이트된 페이징 피드 응답객체를 반환
 	 */
 	@Transactional
-	public PagedFeedResponseDto deleteFeed(Long id, String password) {
+	public FeedPageResponseDto deleteFeed(Long id, String password) {
 		// FIXME: 비밀번호 검증 로직 필요
 		// FIXME: 로그인 유저 권한여부 로직 필요
-
 		Feed feed = feedRepository.findById(id)
 			.orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "존재하지 않는 게시글입니다."));
 
 		feedRepository.delete(feed);
-
-		return this.findAllFeed(getDefaultPageable());
-	}
-
-	/**
-	 * 🚀 기본 페이징 객체를 반환하는 메서드 (생성일 내림차순)
-	 * @return 페이징 객체를 반환
-	 */
-	private Pageable getDefaultPageable() {
-		return PageRequest.of(
-			0,
-			10,
-			Sort.by(Sort.Direction.DESC, "createdAt"));
+		return this.findAllFeed(0, 10);
 	}
 }


### PR DESCRIPTION
## 🔎 작업 내용

- 예외처리를 구현하였습니다.
- `ExceptionCode`를 공통으로 사용할 수 있게  `enum`으로 추가하였습니다.
-  `CustomException`로 모든 예외처리 정보를 규격화 및 커스텀하였습니다.
- `GlobalExceptionHandler`를 생성하여 예외처리 응답을 적절하게 하도록 하였습니다.

  <br/>

## ➕ 트러블 슈팅

- 저희 `merge` 작업 한번 해야될 것 같습니다..

  <br/>

## 🔧 해결해야할 문제

- 공통 예외처리