### PR TITLE
[REFACTOR] 뉴스피드 리팩토링

### DIFF
--- a/src/main/java/com/newspeed19/feed/controller/FeedController.java
+++ b/src/main/java/com/newspeed19/feed/controller/FeedController.java
@@ -20,6 +20,7 @@ import com.newspeed19.feed.dto.response.FeedDetailResponseDto;
 import com.newspeed19.feed.dto.response.FeedPageResponseDto;
 import com.newspeed19.feed.service.FeedService;
 
+import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 
 @RestController
@@ -37,9 +38,10 @@ public class FeedController {
 	@GetMapping
 	public ResponseEntity<ApiResponseDto<FeedPageResponseDto>> findAll(
 		@RequestParam(defaultValue = "1") int page,
-		@RequestParam(defaultValue = "10") int size
+		@RequestParam(defaultValue = "10") int size,
+		HttpServletRequest request
 	) {
-		FeedPageResponseDto responseDto = feedService.findAllFeed(page, size);
+		FeedPageResponseDto responseDto = feedService.findAllFeed(getLoginUserId(request), page, size);
 
 		ApiResponseDto<FeedPageResponseDto> apiResponseDto = ApiResponseDto.<FeedPageResponseDto>builder()
 			.code(HttpStatus.OK.value())
@@ -77,9 +79,10 @@ public class FeedController {
 	 */
 	@PostMapping("/create")
 	public ResponseEntity<ApiResponseDto<FeedDetailResponseDto>> create(
-		@Validated(FeedRequestGroups.Create.class) @RequestBody FeedRequestDto dto
+		@Validated(FeedRequestGroups.Create.class) @RequestBody FeedRequestDto dto,
+		HttpServletRequest request
 	) {
-		FeedDetailResponseDto responseDto = feedService.createFeed(dto);
+		FeedDetailResponseDto responseDto = feedService.createFeed(getLoginUserId(request), dto);
 
 		ApiResponseDto<FeedDetailResponseDto> apiResponseDto = ApiResponseDto.<FeedDetailResponseDto>builder()
 			.code(HttpStatus.CREATED.value())
@@ -99,9 +102,10 @@ public class FeedController {
 	@PatchMapping("/{id}")
 	public ResponseEntity<ApiResponseDto<FeedDetailResponseDto>> update(
 		@PathVariable Long id,
-		@Validated(FeedRequestGroups.Update.class) @RequestBody FeedRequestDto dto
+		@Validated(FeedRequestGroups.Update.class) @RequestBody FeedRequestDto dto,
+		HttpServletRequest request
 	) {
-		FeedDetailResponseDto responseDto = feedService.updateFeed(dto, id);
+		FeedDetailResponseDto responseDto = feedService.updateFeed(dto, getLoginUserId(request), id);
 
 		ApiResponseDto<FeedDetailResponseDto> apiResponseDto = ApiResponseDto.<FeedDetailResponseDto>builder()
 			.code(HttpStatus.OK.value())
@@ -121,9 +125,10 @@ public class FeedController {
 	@DeleteMapping("/{id}")
 	public ResponseEntity<ApiResponseDto<FeedPageResponseDto>> delete(
 		@PathVariable Long id,
-		@Validated(FeedRequestGroups.Delete.class) @RequestBody FeedRequestDto dto
+		@Validated(FeedRequestGroups.Delete.class) @RequestBody FeedRequestDto dto,
+		HttpServletRequest request
 	) {
-		FeedPageResponseDto responseDto = feedService.deleteFeed(id, dto.getPassword());
+		FeedPageResponseDto responseDto = feedService.deleteFeed(getLoginUserId(request), id);
 
 		ApiResponseDto<FeedPageResponseDto> apiResponseDto = ApiResponseDto.<FeedPageResponseDto>builder()
 			.code(HttpStatus.OK.value())
@@ -132,5 +137,14 @@ public class FeedController {
 			.data(responseDto)
 			.build();
 		return new ResponseEntity<>(apiResponseDto, HttpStatus.OK);
+	}
+
+	/**
+	 * 🚀 세션에 저장되어 있는 로그인 유저 아이디 가져오는 메서드
+	 * @param request HttpServletRequest 객체
+	 * @return Long 타입의 로그인 유저 아이디 반환
+	 */
+	private Long getLoginUserId(HttpServletRequest request) {
+		return (Long)request.getAttribute("userId");
 	}
 }

--- a/src/main/java/com/newspeed19/feed/dto/request/FeedRequestDto.java
+++ b/src/main/java/com/newspeed19/feed/dto/request/FeedRequestDto.java
@@ -22,8 +22,4 @@ public class FeedRequestDto {
 
 	@NotBlank(message = "이미지를 첨부해주세요.", groups = {Create.class, Update.class})
 	private final String image;
-
-	@NotBlank(message = "비밀번호를 입력해주세요.", groups = {Create.class, Update.class, Delete.class})
-	@Size(max = 20, message = "비밀번호는 20자를 넘을 수 없습니다.", groups = {Create.class, Update.class, Delete.class})
-	private final String password;
 }

--- a/src/main/java/com/newspeed19/feed/dto/response/FeedDetailResponseDto.java
+++ b/src/main/java/com/newspeed19/feed/dto/response/FeedDetailResponseDto.java
@@ -2,7 +2,8 @@ package com.newspeed19.feed.dto.response;
 
 import java.util.List;
 
-import com.newspeed19.user.entity.User;
+import com.newspeed19.comment.dto.response.CommentResponseDto;
+import com.newspeed19.user.profile.dto.UserProfileResponseDto;
 
 import lombok.Getter;
 import lombok.experimental.SuperBuilder;
@@ -13,6 +14,6 @@ import lombok.experimental.SuperBuilder;
 @Getter
 @SuperBuilder
 public class FeedDetailResponseDto extends FeedResponseDto {
-	private final User user; // FIXME: UserResponseDto 로 변경 예정
-	private final List<String> comment; // FIXME: CommentResponseDto 로 변경 예정
+	private final UserProfileResponseDto user;
+	private final List<CommentResponseDto> comments;
 }

--- a/src/main/java/com/newspeed19/feed/repository/FeedRepository.java
+++ b/src/main/java/com/newspeed19/feed/repository/FeedRepository.java
@@ -1,8 +1,19 @@
 package com.newspeed19.feed.repository;
 
+import java.util.List;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.newspeed19.feed.entity.Feed;
 
 public interface FeedRepository extends JpaRepository<Feed, Long> {
+	/**
+	 * [Repo] userId 목록으로 피드를 조회하는 메서드
+	 * @param userIds userId 목록 (ex: 나를 팔로우한 유저 아이디 목록)
+	 * @param pageable 페이징 객체
+	 * @return 페이징된 피드 객체
+	 */
+	Page<Feed> findByUserIdIn(List<Long> userIds, Pageable pageable);
 }

--- a/src/main/java/com/newspeed19/feed/service/FeedService.java
+++ b/src/main/java/com/newspeed19/feed/service/FeedService.java
@@ -10,6 +10,8 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.server.ResponseStatusException;
 
+import com.newspeed19.comment.dto.response.CommentResponseDto;
+import com.newspeed19.comment.repository.CommentRepository;
 import com.newspeed19.feed.dto.request.FeedRequestDto;
 import com.newspeed19.feed.dto.response.FeedDetailResponseDto;
 import com.newspeed19.feed.dto.response.FeedPageResponseDto;
@@ -18,14 +20,23 @@ import com.newspeed19.feed.entity.Feed;
 import com.newspeed19.feed.exception.CustomException;
 import com.newspeed19.feed.exception.ExceptionCode;
 import com.newspeed19.feed.repository.FeedRepository;
+import com.newspeed19.follow.repository.FollowRepository;
+import com.newspeed19.user.entity.User;
+import com.newspeed19.user.profile.dto.UserProfileResponseDto;
+import com.newspeed19.user.profile.service.ProfileServiceImpl;
+import com.newspeed19.user.repository.UserRepository;
 
 import lombok.RequiredArgsConstructor;
 
 @Service
 @RequiredArgsConstructor
 public class FeedService {
+	private final ProfileServiceImpl profileService;
 
 	private final FeedRepository feedRepository;
+	private final FollowRepository followRepository;
+	private final CommentRepository commentRepository;
+	private final UserRepository userRepository;
 
 	/**
 	 * [Service] 전체 피드를 조회하는 메서드
@@ -34,23 +45,43 @@ public class FeedService {
 	 * @return 페이징된 피드 응답객체를 반환
 	 */
 	@Transactional(readOnly = true)
-	public FeedPageResponseDto findAllFeed(int page, int size) {
+	public FeedPageResponseDto findAllFeed(Long userId, int page, int size) {
 		// 페이징 객체 생성
 		int adjustedPage = (page > 0) ? page - 1 : 0;
 		PageRequest pageable = PageRequest.of(adjustedPage, size, Sort.by("updatedAt").descending());
 
-		// 페이징된 피드목록 응답객체 생성
-		Page<FeedResponseDto> feedPageResponseDto = feedRepository.findAll(pageable)
-			.map(feed ->
-				// FIXME: 댓글 불러오기 로직 추가 예정
-				FeedResponseDto.builder()
-					.id(feed.getId())
-					.contents(feed.getContents())
-					.image(feed.getImage())
-					.createdAt(feed.getCreatedAt())
-					.updatedAt(feed.getUpdatedAt())
-					.build()
-			);
+		// 내가 팔로우한 유저 ID 리스트 조회
+		List<Long> followingIds = followRepository.findByFollowingUserIds(userId);
+
+		Page<FeedResponseDto> feedPageResponseDto;
+
+		// 팔로우가 없을 경우, 전체 피드 목록 조회
+		if (followingIds.isEmpty()) {
+			feedPageResponseDto = feedRepository.findAll(pageable)
+				.map(feed ->
+					// FIXME: 댓글 불러오기 로직 추가 예정
+					FeedResponseDto.builder()
+						.id(feed.getId())
+						.contents(feed.getContents())
+						.image(feed.getImage())
+						.createdAt(feed.getCreatedAt())
+						.updatedAt(feed.getUpdatedAt())
+						.build()
+				);
+		} else { // 팔로우가 있을 경우, 팔로우한 사람들의 피드 목록 조회
+			feedPageResponseDto = feedRepository.findByUserIdIn(followingIds, pageable)
+				.map(feed ->
+					// FIXME: 댓글 불러오기 로직 추가 예정
+					FeedResponseDto.builder()
+						.id(feed.getId())
+						.contents(feed.getContents())
+						.image(feed.getImage())
+						.createdAt(feed.getCreatedAt())
+						.updatedAt(feed.getUpdatedAt())
+						.build()
+				);
+		}
+
 		// 응답 객체 생성
 		List<FeedResponseDto> feeds = feedPageResponseDto.getContent();
 
@@ -73,32 +104,46 @@ public class FeedService {
 				.exceptionCode(ExceptionCode.FEED_NOT_FOUND)
 				.build());
 
+		// 피드에 달린 댓글 목록 DTO
+		List<CommentResponseDto> comments = commentRepository.findAllByFeedId(id).stream()
+			.map(CommentResponseDto::toDto)
+			.toList();
+
+		// 유저 DTO
+		UserProfileResponseDto myProfile = profileService.getMyProfile(feed.getUser());
+
 		return FeedDetailResponseDto.builder()
 			.id(feed.getId())
 			.contents(feed.getContents())
 			.image(feed.getImage())
 			.createdAt(feed.getCreatedAt())
 			.updatedAt(feed.getUpdatedAt())
-			.user(feed.getUser())
-			.comment(List.of("좋아요!", "응원합니다")) // FIXME: comments 응답 객체
+			.user(myProfile)
+			.comments(comments)
 			.build();
 	}
 
 	/**
 	 * [Service] 피드를 생성하는 메서드
+	 * @param loginUserId 로그인 유저 id
 	 * @param dto 사용자 요청 DTO
 	 * @return 생성된 상세피드 응답객체를 반환
 	 */
 	@Transactional
-	public FeedDetailResponseDto createFeed(FeedRequestDto dto) {
-		// FIXME: 비밀번호 검증 로직 필요
+	public FeedDetailResponseDto createFeed(Long loginUserId, FeedRequestDto dto) {
+		// 로그인 유저 FIXME: LoginService 구현 해야 함
+		User user = userRepository.findById(loginUserId)
+			.orElseThrow(() -> new IllegalArgumentException("해당 사용자를 찾을 수 없습니다."));
 
-		// FIXME: User 저장해야 함
+		// 유저 DTO
+		UserProfileResponseDto myProfile = profileService.getMyProfile(user);
+
 		// 피드 생성
 		Feed feed = feedRepository.save(
 			Feed.builder()
 				.contents(dto.getContents())
 				.image(dto.getImage())
+				.user(user)
 				.build()
 		);
 
@@ -108,22 +153,38 @@ public class FeedService {
 			.image(feed.getImage())
 			.createdAt(feed.getCreatedAt())
 			.updatedAt(feed.getUpdatedAt())
-			.user(feed.getUser())
-			.comment(List.of("좋아요!", "응원합니다")) // FIXME: comments 응답 객체
+			.user(myProfile)
 			.build();
 	}
 
 	/**
 	 * [Service] 피드를 수정하는 메서드
 	 * @param dto 사용자 요청 DTO
+	 * @param loginUserId 로그인 유저 id
 	 * @param id 피드 id
 	 * @return 수정된 상세피드 응답객체를 반환
 	 */
 	@Transactional
-	public FeedDetailResponseDto updateFeed(FeedRequestDto dto, Long id) {
-		// FIXME: 비밀번호 검증 로직 필요
+	public FeedDetailResponseDto updateFeed(FeedRequestDto dto, Long loginUserId, Long id) {
 		Feed feed = feedRepository.findById(id)
 			.orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "존재하지 않는 게시글입니다."));
+
+		// 로그인 유저가 작성한 피드가 아닐 경우 예외 처리
+		if (!loginUserId.equals(feed.getUser().getId())) {
+			throw new ResponseStatusException(HttpStatus.FORBIDDEN, "수정 권한이 없습니다.");
+		}
+
+		// 로그인 유저 FIXME: LoginService 구현 해야 함
+		User user = userRepository.findById(loginUserId)
+			.orElseThrow(() -> new IllegalArgumentException("해당 사용자를 찾을 수 없습니다."));
+
+		// 유저 DTO
+		UserProfileResponseDto myProfile = profileService.getMyProfile(user);
+
+		// 피드에 달린 댓글 목록 DTO
+		List<CommentResponseDto> comments = commentRepository.findAllByFeedId(id).stream()
+			.map(CommentResponseDto::toDto)
+			.toList();
 
 		// Feed 업데이트
 		feed.updateFeed(dto.getImage(), dto.getContents());
@@ -134,25 +195,28 @@ public class FeedService {
 			.image(feed.getImage())
 			.createdAt(feed.getCreatedAt())
 			.updatedAt(feed.getUpdatedAt())
-			.user(feed.getUser())
-			.comment(List.of("좋아요!", "응원합니다")) // FIXME: comments 응답 객체
+			.user(myProfile)
+			.comments(comments)
 			.build();
 	}
 
 	/**
 	 * [Service] 피드를 삭제하는 메서드
-	 * @param id 피드 Id
-	 * @param password 유저 비밀번호
+	 * @param loginUserId 로그인 유저 id
+	 * @param feedId 피드 Id
 	 * @return 업데이트된 페이징 피드 응답객체를 반환
 	 */
 	@Transactional
-	public FeedPageResponseDto deleteFeed(Long id, String password) {
-		// FIXME: 비밀번호 검증 로직 필요
-		// FIXME: 로그인 유저 권한여부 로직 필요
-		Feed feed = feedRepository.findById(id)
+	public FeedPageResponseDto deleteFeed(Long loginUserId, Long feedId) {
+		Feed feed = feedRepository.findById(feedId)
 			.orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "존재하지 않는 게시글입니다."));
 
+		// 로그인 유저가 작성한 피드가 아닐 경우 예외 처리
+		if (!loginUserId.equals(feed.getUser().getId())) {
+			throw new ResponseStatusException(HttpStatus.FORBIDDEN, "수정 권한이 없습니다.");
+		}
+
 		feedRepository.delete(feed);
-		return this.findAllFeed(0, 10);
+		return this.findAllFeed(loginUserId, 0, 10);
 	}
 }

--- a/src/main/java/com/newspeed19/follow/repository/FollowRepository.java
+++ b/src/main/java/com/newspeed19/follow/repository/FollowRepository.java
@@ -6,6 +6,8 @@ import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import com.newspeed19.follow.entity.Follow;
 import com.newspeed19.follow.entity.FollowStatus;
@@ -25,4 +27,7 @@ public interface FollowRepository extends JpaRepository<Follow, Long> {
 	Page<Follow> findByFollowerAndStatus(User follower, FollowStatus status, Pageable pageable);
 
 	Page<Follow> findByFollowingAndStatus(User following, FollowStatus status, Pageable pageable);
+
+	@Query("SELECT f.following.id FROM Follow f WHERE f.follower.id = :userId AND f.status = 'ACCEPTED'")
+	List<Long> findByFollowingUserIds(@Param("userId") Long userId);
 }


### PR DESCRIPTION
## 🔎 작업 내용

- 뉴스피드 목록 조회할 때, 팔로우 정렬하여 조회
팔로우가 없다면 전체 목록 조회
- 피드 내 비밀번호 로직 삭제
- 피드와 유저,댓글 연동

  <br/>

## ➕ 트러블 슈팅


  <br/>

## 🔧 해결해야할 문제

- 좋아요 및 댓글 연동

  <br/>

<br/>