### PR TITLE
[FEAT] 피드 기간별 검색기능 추가

### DIFF
--- a/src/main/java/com/newspeed19/feed/controller/FeedController.java
+++ b/src/main/java/com/newspeed19/feed/controller/FeedController.java
@@ -1,5 +1,8 @@
 package com.newspeed19.feed.controller;
 
+import java.time.LocalDate;
+
+import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
@@ -37,11 +40,15 @@ public class FeedController {
 	 */
 	@GetMapping
 	public ResponseEntity<ApiResponseDto<FeedPageResponseDto>> findAll(
+		@RequestParam(value = "startDate", required = false)
+		@DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate startDate,
+		@RequestParam(value = "endDate", required = false)
+		@DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate endDate,
 		@RequestParam(defaultValue = "1") int page,
 		@RequestParam(defaultValue = "10") int size,
 		HttpServletRequest request
 	) {
-		FeedPageResponseDto responseDto = feedService.findAllFeed(getLoginUserId(request), page, size);
+		FeedPageResponseDto responseDto = feedService.findAllFeed(startDate, endDate, getLoginUserId(request), page, size);
 
 		ApiResponseDto<FeedPageResponseDto> apiResponseDto = ApiResponseDto.<FeedPageResponseDto>builder()
 			.code(HttpStatus.OK.value())

--- a/src/main/java/com/newspeed19/feed/entity/Feed.java
+++ b/src/main/java/com/newspeed19/feed/entity/Feed.java
@@ -1,21 +1,14 @@
 package com.newspeed19.feed.entity;
 
-import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.springframework.data.annotation.CreatedDate;
-import org.springframework.data.annotation.LastModifiedDate;
-import org.springframework.data.jpa.domain.support.AuditingEntityListener;
-
-import com.newspeed19.comment.entity.CommentLike;
 import com.newspeed19.common.entity.BaseEntity;
 import com.newspeed19.user.entity.User;
 
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
-import jakarta.persistence.EntityListeners;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;

--- a/src/main/java/com/newspeed19/feed/repository/FeedRepository.java
+++ b/src/main/java/com/newspeed19/feed/repository/FeedRepository.java
@@ -1,5 +1,6 @@
 package com.newspeed19.feed.repository;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 import org.springframework.data.domain.Page;
@@ -10,10 +11,23 @@ import com.newspeed19.feed.entity.Feed;
 
 public interface FeedRepository extends JpaRepository<Feed, Long> {
 	/**
-	 * [Repo] userId 목록으로 피드를 조회하는 메서드
+	 * [Repo] 기간별 userId 목록으로 피드를 조회하는 메서드
 	 * @param userIds userId 목록 (ex: 나를 팔로우한 유저 아이디 목록)
+	 * @param start 시작날짜
+	 * @param end 마지막날짜
 	 * @param pageable 페이징 객체
 	 * @return 페이징된 피드 객체
 	 */
-	Page<Feed> findByUserIdIn(List<Long> userIds, Pageable pageable);
+	Page<Feed> findByUserIdInAndCreatedAtBetween(List<Long> userIds, LocalDateTime start, LocalDateTime end, Pageable pageable);
+
+
+	/**
+	 * [Repo] 기간별 작성된 피드를 가지고 오는 메서드
+	 * @param start 시작날짜
+	 * @param end 마지막날짜
+	 * @param pageable 페이징 객체
+	 * @return 페이징된 피드 객체
+	 */
+	Page<Feed> findAllByCreatedAtBetween(LocalDateTime start, LocalDateTime end, Pageable pageable);
+
 }

--- a/src/main/java/com/newspeed19/feed/service/FeedService.java
+++ b/src/main/java/com/newspeed19/feed/service/FeedService.java
@@ -1,5 +1,8 @@
 package com.newspeed19.feed.service;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -51,7 +54,15 @@ public class FeedService {
 	 * @return 페이징된 피드 응답객체를 반환
 	 */
 	@Transactional(readOnly = true)
-	public FeedPageResponseDto findAllFeed(Long userId, int page, int size) {
+	public FeedPageResponseDto findAllFeed(LocalDate startDate, LocalDate endDate, Long userId, int page, int size) {
+		// 기간별 검색 기본값: 최근 1개월
+		LocalDate today = LocalDate.now();
+		if (endDate == null) endDate = today;
+		if (startDate == null) startDate = endDate.minusMonths(1);
+
+		LocalDateTime start = startDate.atStartOfDay(); // 00:00:00
+		LocalDateTime end = endDate.atTime(LocalTime.MAX); // 23:59:59
+
 		// 페이징 객체 생성
 		int adjustedPage = (page > 0) ? page - 1 : 0;
 		PageRequest pageable = PageRequest.of(adjustedPage, size, Sort.by("updatedAt").descending());
@@ -62,11 +73,9 @@ public class FeedService {
 		Page<FeedResponseDto> feedPageResponseDto;
 
 		// 팔로우가 없을 경우, 전체 피드 목록 조회
-
 		if (followingIds.isEmpty()) {
-			feedPageResponseDto = feedRepository.findAll(pageable)
+			feedPageResponseDto = feedRepository.findAllByCreatedAtBetween(start, end, pageable)
 				.map(feed ->
-					// FIXME: likes 카운트 넣어야 됨
 					FeedResponseDto.builder()
 						.id(feed.getId())
 						.contents(feed.getContents())
@@ -78,9 +87,8 @@ public class FeedService {
 						.build()
 				);
 		} else { // 팔로우가 있을 경우, 팔로우한 사람들의 피드 목록 조회
-			feedPageResponseDto = feedRepository.findByUserIdIn(followingIds, pageable)
+			feedPageResponseDto = feedRepository.findByUserIdInAndCreatedAtBetween(followingIds, start, end, pageable)
 				.map(feed ->
-					// FIXME: likes 카운트 넣어야 됨
 					FeedResponseDto.builder()
 						.id(feed.getId())
 						.contents(feed.getContents())
@@ -125,10 +133,10 @@ public class FeedService {
 		UserProfileResponseDto myProfile = profileService.getMyProfile(feed.getUser());
 
 		return FeedDetailResponseDto.builder()
-			// FIXME: likes 카운트 넣어야 됨
 			.id(feed.getId())
 			.contents(feed.getContents())
 			.image(feed.getImage())
+			.likes(feedLikeRepository.countByFeedId(feed.getId()))
 			.commentCount(commentRepository.countByFeedId(feed.getId()))
 			.createdAt(feed.getCreatedAt())
 			.updatedAt(feed.getUpdatedAt())
@@ -201,8 +209,6 @@ public class FeedService {
 
 		// Feed 업데이트
 		feed.updateFeed(dto.getImage(), dto.getContents());
-
-		// FIXME: feedLikes 좋아요 개수 넣어야 됨
 		return FeedDetailResponseDto.builder()
 			.id(feed.getId())
 			.contents(feed.getContents())
@@ -233,9 +239,14 @@ public class FeedService {
 		}
 
 		feedRepository.delete(feed);
-		return this.findAllFeed(loginUserId, 0, 10);
+		return this.findAllFeed(LocalDate.now(), LocalDate.now().minusMonths(1), loginUserId,  0, 10);
 	}
 
+	/**
+	 * [Service] 좋아요 기능 메서드
+	 * @param feedId 피드 id
+	 * @param userId 유저 id
+	 */
 	@Transactional
 	public void toggleLike(Long feedId, Long userId){
 		Feed feed = feedRepository.findById(feedId).orElseThrow(() -> FeedException


### PR DESCRIPTION
## 🔎 작업 내용

- 피드에 startDate, endDate 쿼리파라미터 값을 이용해 기간별 검색기능을 추가하였습니다.
- 값이 들어오지 않으면 최근 1개월내에 팔로우들의 전체 피드를 조회합니다.

  <br/>

## ➕ 트러블 슈팅

-

  <br/>

## 🔧 해결해야할 문제

- 피드 좋아요순 조회를 넣고 싶은데, 어떻게 넣어야될지 모르겠네요 ㅠ

  <br/>

<br/>